### PR TITLE
Fix ace handling bug in calculate_hand

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -11,7 +11,7 @@ def calculate_hand(cards):
     if sum(cards) == 21 and len(cards) == 2:
         return 0
 
-    if 11 in cards and sum(cards) > 21:
+    while 11 in cards and sum(cards) > 21:
         cards.remove(11)
         cards.append(1)
 


### PR DESCRIPTION
## Summary
- handle multiple aces correctly when calculating hand totals

## Testing
- `python3 -m py_compile *.py`
- `python3 - <<'PY'
import functions
hand = [11, 11, 10]
print('Before calculate:', hand, 'sum=', sum(hand))
print('After calculate:', hand, 'score=', functions.calculate_hand(hand))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684ef87493d883288f23bfa070b05b42